### PR TITLE
Fix windows file-system case sensitivity when relativising files 

### DIFF
--- a/src/com/fivium/scriptrunner2/builder/ManifestBuilder.java
+++ b/src/com/fivium/scriptrunner2/builder/ManifestBuilder.java
@@ -17,7 +17,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;

--- a/src/com/fivium/scriptrunner2/builder/ManifestBuilder.java
+++ b/src/com/fivium/scriptrunner2/builder/ManifestBuilder.java
@@ -17,6 +17,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
@@ -145,7 +148,10 @@ implements FileResolver {
   
   @Override
   public String relativeFilePath(File pFile){
-    return ScriptRunner.normaliseFilePath(mBaseDirectory.toURI().relativize(pFile.toURI()).getPath());
+    Path lBaseDirectoryPath = FileSystems.getDefault().getPath(mBaseDirectory.getAbsolutePath());
+    Path lFilePath = FileSystems.getDefault().getPath(pFile.getAbsolutePath());
+    Path lRelative = lBaseDirectoryPath.relativize(lFilePath);
+    return ScriptRunner.normaliseFilePath(lRelative.toString());
   }  
   
   /**


### PR DESCRIPTION
There is a bug where, if the file location passed to scriptbuilder is differently cased to the uri-ed file, the file hashing function would fail.

Now uses NIO path comparisons, so is platform independent.
