### PR TITLE
Add command line option "-nounimplicatedfiles".

### DIFF
--- a/src/com/fivium/scriptrunner2/CommandLineOption.java
+++ b/src/com/fivium/scriptrunner2/CommandLineOption.java
@@ -25,7 +25,8 @@ public enum CommandLineOption {
   , DB_SYSDBA("sysdba")
   , OUTPUT_FILE_PATH("outfile")
   , PROMOTION_LABEL("label")
-  , ADDITIONAL_PROPERTIES("props");
+  , ADDITIONAL_PROPERTIES("props")
+  , NO_UNIMPLICATED_FILES("nounimplicatedfiles");
   
   private final String mArgString;
   

--- a/src/com/fivium/scriptrunner2/CommandLineWrapper.java
+++ b/src/com/fivium/scriptrunner2/CommandLineWrapper.java
@@ -84,6 +84,8 @@ public class CommandLineWrapper {
     gCommandLineOptions.addOption(CommandLineOption.OUTPUT_FILE_PATH.getArgString(), true, "(Build only) File path where the output will be written to. Default is {CURRENT_DIR}/{PROMOTE_LABEL}.zip");
     gCommandLineOptions.addOption(CommandLineOption.PROMOTION_LABEL.getArgString(), true, "(Build only) Promotion label for builder.");
     gCommandLineOptions.addOption(CommandLineOption.ADDITIONAL_PROPERTIES.getArgString(), true, "(Build only) Location of the additional properties file for the builder.");
+
+    gCommandLineOptions.addOption(CommandLineOption.NO_UNIMPLICATED_FILES.getArgString(), false, "(Build only) Error (rather than warn) if files are found in source directory but not implicated by manifest builder rules.");
     
     //gCommandLineOptions.addOption("help", false, "Prints help.");
   }

--- a/src/com/fivium/scriptrunner2/ScriptBuilder.java
+++ b/src/com/fivium/scriptrunner2/ScriptBuilder.java
@@ -97,9 +97,19 @@ public class ScriptBuilder {
     lFilePathsInBaseDirectory.removeAll(lImplicatedManifestFilePaths);
     
     if(lFilePathsInBaseDirectory.size() > 0){
-      Logger.logWarning(lFilePathsInBaseDirectory.size() + " files found in source directory but not implicated by manifest builder rules:");
-      for(String lPath : lFilePathsInBaseDirectory){
-        Logger.logInfo(lPath);
+      String warningMessage = lFilePathsInBaseDirectory.size() + " files found in source directory but not implicated by manifest builder rules:";
+      if(pOptionWrapper.hasOption(CommandLineOption.NO_UNIMPLICATED_FILES)){
+        StringBuilder errorMessage = new StringBuilder();
+        errorMessage.append(warningMessage + "\n");
+        for (String lPath : lFilePathsInBaseDirectory) {
+          errorMessage.append(lPath + "\n");
+        }
+        throw new ExManifestBuilder(errorMessage.toString());
+      } else {
+        Logger.logWarning(warningMessage);
+        for (String lPath : lFilePathsInBaseDirectory) {
+          Logger.logInfo(lPath);
+        }
       }
     }
     


### PR DESCRIPTION
This causes ScriptRunner to raise an exception rather than log a warning when files are found in the source directory that are not implicated in the manifest.

Implements #3 
